### PR TITLE
feat: [Breking Change] Support Node 18 or later

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [18.x, 20.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # ChangeLog
 
+## v2.0.0
+
+### Breaking Changes
+
+- Support Node.js v18 or later
+
+### Changes
+
+- chore: update deps and remove unnecessary packages [#40](https://github.com/akabekobeko/npm-cross-conf-env/pull/40)
+
 ## v1.3.0
 
 ### Breaking Changes

--- a/examples/package.json
+++ b/examples/package.json
@@ -2,7 +2,7 @@
   "name": "examples-cross-conf-env",
   "description": "Examples for the cross-conf-env.",
   "private": true,
-  "version": "1.3.0",
+  "version": "2.0.0",
   "author": "akabeko (http://akabeko.me/)",
   "license": "MIT",
   "main": "index.js",
@@ -19,7 +19,7 @@
     "task:c-param": "npm run task:c --foo=Foo --bar=Bar --baz=Baz"
   },
   "devDependencies": {
-    "cross-conf-env": "^1.3.0",
+    "cross-conf-env": "^2.0.0",
     "npm-run-all": "^4.1.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "cross-conf-env",
   "description": "To cross-platform the config and root variable reference of package.json in npm-scripts.",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "author": "akabeko",
   "license": "MIT",
   "engines": {
-    "node": ">= 14"
+    "node": ">= 18"
   },
   "main": "dist/lib/index.js",
   "bin": "dist/bin/index.js",


### PR DESCRIPTION
Since the Node.js LTS has been updated to 18, we will also adjust the lower version limit of support.